### PR TITLE
Feat: test data and simulation for bills and transactions

### DIFF
--- a/app/Console/Commands/DemoJobCommand.php
+++ b/app/Console/Commands/DemoJobCommand.php
@@ -1,0 +1,475 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\BillStatus;
+use App\Enums\PropertyType;
+use App\Enums\TransactionStatus;
+use App\Models\Bill;
+use App\Models\Landlord;
+use App\Models\Property;
+use App\Models\Room;
+use App\Models\Tenant;
+use App\Models\Transaction;
+use App\Models\User;
+use Carbon\Carbon;
+use Hash;
+use Illuminate\Console\Command;
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\note;
+use function Laravel\Prompts\outro;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\table;
+use function Laravel\Prompts\warning;
+
+/**
+ * Scenario 1: New tenant with 1 unpaid bill
+ * Scenario 2: Tenant stayed 3 months, all previous bills paid, 1 unpaid for next month
+ * Scenario 3: Tenant stayed 1 month, current bill will be overdue
+ * Scenario 4: Tenant stayed 5 months, last month is overdue + current month overdue
+ */
+
+class DemoJobCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'demo:job';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create demo tenants for showcasing billing jobs';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        info('🏠 Demo Job Command');
+        note('This command creates demo tenants and bills to showcase your billing job functionality.');
+
+        $hasExistingData = $this->checkExistingDemoData();
+
+        if ($hasExistingData) {
+            warning('Demo data already exists!');
+
+            $action = select(
+                'What would you like to do?',
+                [
+                    'status' => '📊 Show current demo status',
+                    'clean' => '🧹 Clean existing demo data',
+                    'add' => '➕ Add more scenarios',
+                    'exit' => '❌ Exit'
+                ],
+                default: 'status'
+            );
+
+            match ($action) {
+                'status' => $this->showStatus(),
+                'clean' => $this->handleCleanData(),
+                'add' => $this->handleCreateScenarios(),
+                'exit' => outro('👋 Goodbye!')
+            };
+        } else {
+            $this->handleCreateScenarios();
+        }
+    }
+
+    private function checkExistingDemoData(): bool
+    {
+        return Tenant::whereHas('user', function ($query) {
+            $query->where('email', 'like', 'tenant.s%@demo.com');
+        })->exists();
+    }
+
+    private function handleCleanData(): void
+    {
+        $confirmed = confirm('Are you sure you want to clean all demo data?', false);
+
+        if (!$confirmed) {
+            info('Operation cancelled.');
+            return;
+        }
+
+        $this->cleanDemoData();
+        info('✅ Demo data cleaned successfully!');
+
+        $createNew = confirm('Would you like to create new demo scenarios?', true);
+        if ($createNew) {
+            $this->handleCreateScenarios();
+        } else {
+            outro('Demo data cleaned. Run the command again to create new scenarios.');
+        }
+    }
+
+    private function handleCreateScenarios(): void
+    {
+        $scenario = select(
+            'Which demo scenario would you like to create?',
+            [
+                '1' => '🆕 Scenario 1: New tenant with 1 unpaid bill',
+                '2' => '💰 Scenario 2: 3-month tenant with all bills paid except current',
+                '3' => '⚠️ Scenario 3: 1-month tenant with overdue bill',
+                '4' => '🚨 Scenario 4: 5-month tenant with multiple overdue bills',
+                'all' => '🎯 Create all scenarios',
+            ],
+            default: 'all'
+        );
+
+        // Get or create landlord and property
+        info('Setting up demo environment...');
+        $landlord = $this->getOrCreateLandlord();
+        $property = $this->getOrCreateProperty($landlord);
+
+        // Create scenarios
+        match ((string) $scenario) {
+            '1' => $this->createScenario1($property),
+            '2' => $this->createScenario2($property),
+            '3' => $this->createScenario3($property),
+            '4' => $this->createScenario4($property),
+            'all' => $this->createAllScenarios($property),
+        };
+
+        info('🎉 Demo scenarios created successfully!');
+        $this->showStatus();
+
+        outro('Demo setup complete! You can now test your billing jobs.');
+    }
+
+    private function createAllScenarios(Property $property): void
+    {
+        info('Creating all demo scenarios...');
+
+        $this->createScenario1($property);
+        $this->createScenario2($property);
+        $this->createScenario3($property);
+        $this->createScenario4($property);
+    }
+
+    private function getOrCreateLandlord(): Landlord
+    {
+        $user = User::firstOrCreate(
+            ['email' => env('DEFAULT_LANDLORD_EMAIL', 'landlord@gmail.com')],
+            [
+                'name' => 'Default Landlord',
+                // 'email_verified_at' => now(),
+                'password' => Hash::make('password'),
+                'role' => 'landlord',
+                'profile_completed' => true,
+            ]
+        );
+
+        if (!$user->hasVerifiedEmail()) {
+            $user->markEmailAsVerified();
+        }
+
+        return Landlord::firstOrCreate(['user_id' => $user->id]);
+    }
+
+    private function getOrCreateProperty(Landlord $landlord): Property
+    {
+        return Property::firstOrCreate([
+            'landlord_id' => $landlord->id,
+            'name' => 'Demo Property',
+        ], [
+            'type' => PropertyType::DORM->value,
+            'description' => 'Property for demo purposes',
+            'address' => '123 Demo Street, Demo City',
+        ]);
+    }
+
+    private function cleanDemoData(): void
+    {
+        // Delete demo tenants and related data
+        $demoUsers = User::where('email', 'like', '%.demo.com')
+            ->orWhere('email', 'like', 'tenant.s%@demo.com')
+            ->get();
+
+        foreach ($demoUsers as $user) {
+            if ($user->tenant) {
+                // Delete related transactions
+                Transaction::where('tenant_id', $user->tenant->id)->delete();
+                // Delete related bills
+                Bill::where('tenant_id', $user->tenant->id)->delete();
+                // Delete tenant
+                $user->tenant->delete();
+            }
+            $user->delete();
+        }
+
+        // Delete demo rooms
+        Room::where('name', 'like', 'Demo Room%')->delete();
+
+        // Delete demo property if no other rooms
+        $demoProperty = Property::where('name', 'Demo Property')->first();
+        if ($demoProperty && $demoProperty->rooms()->count() === 0) {
+            $demoProperty->delete();
+        }
+    }
+
+    /**
+     * Scenario 1: New tenant with 1 unpaid bill
+     */
+    private function createScenario1(Property $property): void
+    {
+        info('🆕 Creating Scenario 1: New tenant with 1 unpaid bill');
+
+        // Create room
+        $room = Room::create([
+            'property_id' => $property->id,
+            'code' => generate_code(),
+            'name' => 'Demo Room S1',
+            'rent_amount' => 5000.00,
+            'max_occupancy' => 2,
+        ]);
+
+        // Create tenant that moved in today (billing day is today)
+        $tenant = $this->createTenant('Demo Tenant S1', 'tenant.s1@demo.com', $room, now());
+
+
+        note("✅ Scenario 1 created - Room: {$room->code}, Move-in: " . now()->format('Y-m-d'));
+    }
+
+    /**
+     * Scenario 2: Tenant stayed 3 months, all previous bills paid, 1 unpaid for next month
+     */
+    private function createScenario2(Property $property): void
+    {
+        info('💰 Creating Scenario 2: 3-month tenant with all bills paid except current');
+
+        // Create room
+        $room = Room::create([
+            'property_id' => $property->id,
+            'code' => generate_code(),
+            'name' => 'Demo Room S2',
+            'rent_amount' => 6000.00,
+            'max_occupancy' => 2,
+        ]);
+
+        // Create tenant that moved in 3 months ago
+        $moveInDate = now()->subMonths(3);
+        $tenant = $this->createTenant('Demo Tenant S2', 'tenant.s2@demo.com', $room, $moveInDate);
+
+        // Create and pay bills for the past 3 months
+        for ($i = 0; $i < 3; $i++) {
+            $dueDate = $moveInDate->copy()->addMonths($i + 1);
+            $createdAt = ($i === 0) ? $moveInDate->copy() : $moveInDate->copy()->addMonths($i);
+
+            $bill = Bill::create([
+                'tenant_id' => $tenant->id,
+                'amount_due' => $tenant->room->rent_amount,
+                'due_date' => $dueDate->endOfDay(),
+                'status' => BillStatus::PAID->value,
+                'created_at' => $createdAt->startOfDay(),
+                'updated_at' => $createdAt->startOfDay(),
+            ]);
+
+            // Create payment transaction
+            $paymentDate = fake()->dateTimeBetween(
+                $createdAt->format('Y-m-d'),
+                $dueDate->format('Y-m-d')
+            );
+
+            Transaction::create([
+                'tenant_id' => $tenant->id,
+                'bill_id' => $bill->id,
+                'payment_method' => 'gcash',
+                'proof_photo' => null,
+                'payment_date' => $paymentDate,
+                'status' => TransactionStatus::COMPLETED->value,
+                'confirmed_at' => $paymentDate,
+            ]);
+        }
+
+        note("✅ Scenario 2 created - Room: {$room->code}, Move-in: " . $moveInDate->format('Y-m-d'));
+    }
+
+    /**
+     * Scenario 3: Tenant stayed 1 month, current bill will be overdue
+     */
+    private function createScenario3(Property $property): void
+    {
+        info('⚠️  Creating Scenario 3: 1-month tenant with overdue bill');
+
+        // Create room
+        $room = Room::create([
+            'property_id' => $property->id,
+            'code' => generate_code(),
+            'name' => 'Demo Room S3',
+            'rent_amount' => 4500.00,
+            'max_occupancy' => 1,
+        ]);
+
+        // Create tenant that moved in 1 month and 1 day ago
+        $moveInDate = now()->subMonths(1)->subDay();
+        $tenant = $this->createTenant('Demo Tenant S3', 'tenant.s3@demo.com', $room, $moveInDate);
+
+
+
+        $bill = Bill::create([
+            'tenant_id' => $tenant->id,
+            'amount_due' => $tenant->room->rent_amount,
+            'due_date' => $moveInDate->copy()->addMonth()->endOfDay(), // Past due date
+            'status' => BillStatus::UNPAID->value,
+            'created_at' => $moveInDate->startOfDay(),
+            'updated_at' => $moveInDate->startOfDay(),
+        ]);
+
+        note("✅ Scenario 3 created - Room: {$room->code}, Move-in: " . $moveInDate->format('Y-m-d'));
+    }
+
+    /**
+     * Scenario 4: Tenant stayed 5 months, last month is overdue + current month overdue
+     */
+    private function createScenario4(Property $property): void
+    {
+        info('🚨 Creating Scenario 4: 5-month tenant with multiple overdue bills');
+
+        // Create room
+        $room = Room::create([
+            'property_id' => $property->id,
+            'code' => generate_code(),
+            'name' => 'Demo Room S4',
+            'rent_amount' => 7000.00,
+            'max_occupancy' => 3,
+        ]);
+
+        // Create tenant that moved in 5 months and 1 day ago
+        $moveInDate = now()->subMonths(5)->subDay();
+        $tenant = $this->createTenant('Demo Tenant S4', 'tenant.s4@demo.com', $room, $moveInDate);
+
+        // Let GenerateBillsJob create the 5th month bill
+        for ($i = 0; $i < 5; $i++) {
+            $dueDate = $moveInDate->copy()->addMonths($i + 1)->endOfDay();
+            $createdAt = ($i === 0) ? $moveInDate->copy() : $moveInDate->copy()->addMonths($i);
+
+            // First 3 months: paid bills
+            if ($i < 3) {
+                $bill = Bill::create([
+                    'tenant_id' => $tenant->id,
+                    'amount_due' => $tenant->room->rent_amount,
+                    'due_date' => $dueDate,
+                    'status' => BillStatus::PAID->value,
+                    'created_at' => $createdAt->startOfDay(),
+                    'updated_at' => $createdAt->startOfDay(),
+                ]);
+
+                // Create payment transaction
+                $paymentDate = fake()->dateTimeBetween(
+                    $createdAt->format('Y-m-d'),
+                    $dueDate->format('Y-m-d')
+                );
+
+                Transaction::create([
+                    'tenant_id' => $tenant->id,
+                    'bill_id' => $bill->id,
+                    'payment_method' => 'cash',
+                    'proof_photo' => null,
+                    'payment_date' => $paymentDate,
+                    'status' => TransactionStatus::COMPLETED->value,
+                    'confirmed_at' => $paymentDate,
+                ]);
+            } else {
+
+                Bill::create([
+                    'tenant_id' => $tenant->id,
+                    'amount_due' => $tenant->room->rent_amount,
+                    'due_date' => $dueDate, // This will be past due
+                    'status' => BillStatus::UNPAID->value,
+                    'created_at' => $createdAt->startOfDay(),
+                    'updated_at' => $createdAt->startOfDay(),
+                ]);
+            }
+        }
+
+        note("✅ Scenario 4 created - Room: {$room->code}, Move-in: " . $moveInDate->format('Y-m-d'));
+    }
+
+    private function createTenant(string $name, string $email, Room $room, Carbon $moveInDate): Tenant
+    {
+        $user = User::create([
+            'name' => $name,
+            'email' => $email,
+            // 'email_verified_at' => now(),
+            'password' => Hash::make('password'),
+            'role' => 'tenant',
+            'profile_completed' => true,
+        ]);
+
+        $user->markEmailAsVerified();
+
+        return Tenant::create([
+            'user_id' => $user->id,
+            'room_id' => $room->id,
+            'move_in_date' => $moveInDate,
+        ]);
+    }
+
+    private function showStatus(): void
+    {
+        $demoTenants = Tenant::whereHas('user', function ($query) {
+            $query->where('email', 'like', 'tenant.s%@demo.com');
+        })->with(['user', 'room', 'bills'])->get();
+
+        if ($demoTenants->isEmpty()) {
+            warning('No demo tenants found.');
+            return;
+        }
+
+        info('📊 Demo Status Overview');
+
+        // Create summary table
+        $summaryData = [];
+        $totalBills = 0;
+        $unpaidBills = 0;
+        $overdueBills = 0;
+        $paidBills = 0;
+
+        foreach ($demoTenants as $tenant) {
+            $bills = $tenant->bills;
+            $unpaid = $bills->where('status', 'unpaid')->count();
+            $overdue = $bills->where('status', 'overdue')->count();
+            $paid = $bills->where('status', 'paid')->count();
+
+            $totalBills += $bills->count();
+            $unpaidBills += $unpaid;
+            $overdueBills += $overdue;
+            $paidBills += $paid;
+
+            $summaryData[] = [
+                'Tenant' => $tenant->user->name,
+                'Room' => $tenant->room->code,
+                'Rent' => '₱' . number_format($tenant->room->rent_amount, 2),
+                'Move-in' => $tenant->move_in_date->format('M j, Y'),
+                'Total Bills' => $bills->count(),
+                'Paid' => $paid > 0 ? "✅ {$paid}" : '-',
+                'Unpaid' => $unpaid > 0 ? "⏳ {$unpaid}" : '-',
+                'Overdue' => $overdue > 0 ? "❌ {$overdue}" : '-',
+            ];
+        }
+
+        table(
+            ['Tenant', 'Room', 'Rent', 'Move-in', 'Total Bills', 'Paid', 'Unpaid', 'Overdue'],
+            $summaryData
+        );
+
+        // Show overall summary
+        info('📈 Overall Summary');
+        table(
+            ['Metric', 'Count'],
+            [
+                ['Total Demo Tenants', $demoTenants->count()],
+                ['Total Bills', $totalBills],
+                ['Paid Bills', "✅ {$paidBills}"],
+                ['Unpaid Bills', "⏳ {$unpaidBills}"],
+                ['Overdue Bills', "❌ {$overdueBills}"],
+            ]
+        );
+    }
+}

--- a/app/Console/Commands/DemoJobCommand.php
+++ b/app/Console/Commands/DemoJobCommand.php
@@ -15,6 +15,7 @@ use App\Models\User;
 use Carbon\Carbon;
 use Hash;
 use Illuminate\Console\Command;
+
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\note;
@@ -29,7 +30,6 @@ use function Laravel\Prompts\warning;
  * Scenario 3: Tenant stayed 1 month, current bill will be overdue
  * Scenario 4: Tenant stayed 5 months, last month is overdue + current month overdue
  */
-
 class DemoJobCommand extends Command
 {
     /**
@@ -65,7 +65,7 @@ class DemoJobCommand extends Command
                     'status' => '📊 Show current demo status',
                     'clean' => '🧹 Clean existing demo data',
                     'add' => '➕ Add more scenarios',
-                    'exit' => '❌ Exit'
+                    'exit' => '❌ Exit',
                 ],
                 default: 'status'
             );
@@ -92,8 +92,9 @@ class DemoJobCommand extends Command
     {
         $confirmed = confirm('Are you sure you want to clean all demo data?', false);
 
-        if (!$confirmed) {
+        if (! $confirmed) {
             info('Operation cancelled.');
+
             return;
         }
 
@@ -165,7 +166,7 @@ class DemoJobCommand extends Command
             ]
         );
 
-        if (!$user->hasVerifiedEmail()) {
+        if (! $user->hasVerifiedEmail()) {
             $user->markEmailAsVerified();
         }
 
@@ -232,8 +233,7 @@ class DemoJobCommand extends Command
         // Create tenant that moved in today (billing day is today)
         $tenant = $this->createTenant('Demo Tenant S1', 'tenant.s1@demo.com', $room, now());
 
-
-        note("✅ Scenario 1 created - Room: {$room->code}, Move-in: " . now()->format('Y-m-d'));
+        note("✅ Scenario 1 created - Room: {$room->code}, Move-in: ".now()->format('Y-m-d'));
     }
 
     /**
@@ -287,7 +287,7 @@ class DemoJobCommand extends Command
             ]);
         }
 
-        note("✅ Scenario 2 created - Room: {$room->code}, Move-in: " . $moveInDate->format('Y-m-d'));
+        note("✅ Scenario 2 created - Room: {$room->code}, Move-in: ".$moveInDate->format('Y-m-d'));
     }
 
     /**
@@ -310,8 +310,6 @@ class DemoJobCommand extends Command
         $moveInDate = now()->subMonths(1)->subDay();
         $tenant = $this->createTenant('Demo Tenant S3', 'tenant.s3@demo.com', $room, $moveInDate);
 
-
-
         $bill = Bill::create([
             'tenant_id' => $tenant->id,
             'amount_due' => $tenant->room->rent_amount,
@@ -321,7 +319,7 @@ class DemoJobCommand extends Command
             'updated_at' => $moveInDate->startOfDay(),
         ]);
 
-        note("✅ Scenario 3 created - Room: {$room->code}, Move-in: " . $moveInDate->format('Y-m-d'));
+        note("✅ Scenario 3 created - Room: {$room->code}, Move-in: ".$moveInDate->format('Y-m-d'));
     }
 
     /**
@@ -388,7 +386,7 @@ class DemoJobCommand extends Command
             }
         }
 
-        note("✅ Scenario 4 created - Room: {$room->code}, Move-in: " . $moveInDate->format('Y-m-d'));
+        note("✅ Scenario 4 created - Room: {$room->code}, Move-in: ".$moveInDate->format('Y-m-d'));
     }
 
     private function createTenant(string $name, string $email, Room $room, Carbon $moveInDate): Tenant
@@ -419,6 +417,7 @@ class DemoJobCommand extends Command
 
         if ($demoTenants->isEmpty()) {
             warning('No demo tenants found.');
+
             return;
         }
 
@@ -445,7 +444,7 @@ class DemoJobCommand extends Command
             $summaryData[] = [
                 'Tenant' => $tenant->user->name,
                 'Room' => $tenant->room->code,
-                'Rent' => '₱' . number_format($tenant->room->rent_amount, 2),
+                'Rent' => '₱'.number_format($tenant->room->rent_amount, 2),
                 'Move-in' => $tenant->move_in_date->format('M j, Y'),
                 'Total Bills' => $bills->count(),
                 'Paid' => $paid > 0 ? "✅ {$paid}" : '-',

--- a/app/Jobs/GenerateBillsJob.php
+++ b/app/Jobs/GenerateBillsJob.php
@@ -26,7 +26,7 @@ class GenerateBillsJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $today = now();
+        $today = now()->startOfDay();
 
         Tenant::all()->each(function (Tenant $tenant) use ($today) {
             $billingDay = Carbon::parse($tenant->move_in_date)->day;
@@ -39,15 +39,22 @@ class GenerateBillsJob implements ShouldQueue
 
             // Check if bill already exists for this user/month
             $exists = Bill::where('tenant_id', $tenant->id)
-                ->whereMonth('due_date', $today->month)
-                ->whereYear('due_date', $today->year)
+                ->whereMonth('created_at', $today->month)
+                ->whereYear('created_at', $today->year)
                 ->exists();
 
-            if (! $exists) {
+            if (!$exists) {
+                $dueDate = $today->copy()->addMonth();
+
+                // Ensure due date uses the same billing day logic
+                $dueDateBillingDay = min($billingDay, $dueDate->daysInMonth);
+                $dueDate->day = $dueDateBillingDay;
+                $dueDate = $dueDate->endOfDay();
+
                 $bill = Bill::create([
                     'tenant_id' => $tenant->id,
-                    'amount_due' => $tenant->room->rent_amount, // or dynamic
-                    'due_date' => $today->copy()->addMonth(), // due 1 month (if that day does not exist, it will fall back to the last valid day of the month)
+                    'amount_due' => $tenant->room->rent_amount,
+                    'due_date' => $dueDate,
                     'status' => 'unpaid',
                 ]);
 

--- a/app/Jobs/UpdateOverdueBillsJob.php
+++ b/app/Jobs/UpdateOverdueBillsJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Enums\BillStatus;
 use App\Models\Bill;
 use App\Notifications\BillOverdue;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -24,13 +25,13 @@ class UpdateOverdueBillsJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $todayStr = now()->toString();
+        $today = now()->startOfDay();
 
         Bill::where('status', 'unpaid')
-            ->where('due_date', '<', $todayStr)
+            ->where('due_date', '<', $today)
             ->get()
             ->each(function (Bill $bill) {
-                $bill->update(['status' => 'overdue']);
+                $bill->update(['status' => BillStatus::OVERDUE->value]);
 
                 if ($bill->tenant && $bill->tenant->user) {
                     $bill->tenant->user->notify(new BillOverdue($bill));

--- a/app/Models/Bill.php
+++ b/app/Models/Bill.php
@@ -11,6 +11,8 @@ class Bill extends Model
         'amount_due',
         'due_date',
         'status',
+        'created_at',
+        'updated_at',
     ];
 
     protected function casts(): array

--- a/app/Models/Landlord.php
+++ b/app/Models/Landlord.php
@@ -11,6 +11,7 @@ class Landlord extends Model
     use HasFactory;
 
     protected $fillable = [
+        'user_id',
         'gcash_qr',
         'maya_qr',
     ];

--- a/database/factories/AnnouncementFactory.php
+++ b/database/factories/AnnouncementFactory.php
@@ -47,7 +47,7 @@ class AnnouncementFactory extends Factory
 
     public function systemWide(): static
     {
-        return $this->state(fn() => [
+        return $this->state(fn () => [
             'type' => AnnouncementType::SYSTEM->value,
             'property_id' => null,
             'room_id' => null,
@@ -56,7 +56,7 @@ class AnnouncementFactory extends Factory
 
     public function propertyWide(?Property $property = null): static
     {
-        return $this->state(fn() => [
+        return $this->state(fn () => [
             'type' => AnnouncementType::PROPERTY->value,
             'property_id' => $property?->id ?? Property::factory(),
             'room_id' => null,
@@ -65,7 +65,7 @@ class AnnouncementFactory extends Factory
 
     public function forRoom(Room $room): static
     {
-        return $this->state(fn() => [
+        return $this->state(fn () => [
             'type' => AnnouncementType::ROOM->value,
             'property_id' => $room->property_id,
             'room_id' => $room->id,
@@ -74,7 +74,7 @@ class AnnouncementFactory extends Factory
 
     public function unrelatedTo(?Property $excludeProperty = null): static
     {
-        return $this->state(function () use ($excludeProperty) {
+        return $this->state(function () {
             // Create a new property that's definitely different
             $property = Property::factory()->create();
             $room = Room::factory()->for($property)->create();

--- a/database/migrations/2025_06_12_013214_create_bills_table.php
+++ b/database/migrations/2025_06_12_013214_create_bills_table.php
@@ -6,7 +6,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     /**
      * Run the migrations.
      */

--- a/database/migrations/2025_06_12_013214_create_bills_table.php
+++ b/database/migrations/2025_06_12_013214_create_bills_table.php
@@ -6,8 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
@@ -17,12 +16,13 @@ return new class extends Migration
             $table->id();
             $table->foreignIdFor(Tenant::class)->constrained()->onDelete('cascade');
             $table->decimal('amount_due', 10, 2);
-            $table->date('due_date');
+            $table->timestamp('due_date');
             $table->enum('status', array_column(BillStatus::cases(), 'value'))
                 ->default(BillStatus::UNPAID->value);
             $table->timestamps();
-        });
 
+            $table->unique(['tenant_id', 'created_at'], 'unique_tenant_monthly_bill');
+        });
     }
 
     /**

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -71,6 +71,7 @@ class DatabaseSeeder extends Seeder
             $tenant = Tenant::firstOrCreate([
                 'user_id' => $user2->id,
                 'room_id' => $room->id,
+                'move_in_date' => now()
             ]);
 
             // $bill = Bill::create([
@@ -105,7 +106,7 @@ class DatabaseSeeder extends Seeder
 
         // For Mocking the website
         if (app()->isLocal()) {
-            $this->callWith(DefaultTestSeeder::class, ['landlord' => $landlord]);
+            // $this->callWith(DefaultTestSeeder::class, ['landlord' => $landlord]);
         }
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -71,7 +71,7 @@ class DatabaseSeeder extends Seeder
             $tenant = Tenant::firstOrCreate([
                 'user_id' => $user2->id,
                 'room_id' => $room->id,
-                'move_in_date' => now()
+                'move_in_date' => now(),
             ]);
 
             // $bill = Bill::create([

--- a/database/seeders/DefaultTestSeeder.php
+++ b/database/seeders/DefaultTestSeeder.php
@@ -3,14 +3,18 @@
 namespace Database\Seeders;
 
 use App\Enums\AnnouncementType;
+use App\Enums\BillStatus;
 use App\Enums\MaintenanceRequestStatus;
 use App\Enums\PropertyType;
+use App\Enums\TransactionStatus;
 use App\Models\Announcement;
+use App\Models\Bill;
 use App\Models\Landlord;
 use App\Models\MaintenanceRequest;
 use App\Models\Property;
 use App\Models\Room;
 use App\Models\Tenant;
+use App\Models\Transaction;
 use App\Models\User;
 use Carbon\Carbon;
 use Hash;
@@ -26,6 +30,7 @@ class DefaultTestSeeder extends Seeder
         $properties = $this->createTestProperties($landlord);
         $rooms = $this->createTestRooms($properties);
         $tenants = $this->createTestTenants($rooms);
+        $this->createTestBillsAndTransactions($tenants);
         $this->createTestMaintenanceRequest($tenants);
         $this->createTestAnnouncements($properties, $rooms);
     }
@@ -101,7 +106,7 @@ class DefaultTestSeeder extends Seeder
                     $rooms[] = Room::create([
                         'property_id' => $property->id,
                         'code' => generate_code(),
-                        'name' => 'Room '.str_pad($i, 3, '0', STR_PAD_LEFT),
+                        'name' => 'Room ' . str_pad($i, 3, '0', STR_PAD_LEFT),
                         'rent_amount' => rand(8, 16) * 500, // 4000-8000
                         'max_occupancy' => rand(1, 6),
                     ]);
@@ -136,6 +141,7 @@ class DefaultTestSeeder extends Seeder
                 $tenant = Tenant::create([
                     'user_id' => $user->id,
                     'room_id' => $room->id,
+                    'move_in_date' => now()->subMonths(rand(3, 12))->day(rand(1, 28)),
                 ]);
 
                 $tenants[] = $tenant;
@@ -143,6 +149,83 @@ class DefaultTestSeeder extends Seeder
         }
 
         return $tenants;
+    }
+
+    /**
+     * @param  Tenant[]  $tenants
+     */
+    private function createTestBillsAndTransactions(array $tenants): void
+    {
+        $paymentMethods = ['cash', 'gcash', 'maya'];
+
+        foreach ($tenants as $tenant) {
+            $moveInDate = Carbon::parse($tenant->move_in_date);
+            $originalDay = $moveInDate->day;
+            $today = now();
+
+            // Calculate exact months stayed (minimum 1 month)
+            $monthsStayed = $moveInDate->diffInMonths($today);
+            $monthsStayed = max(1, $monthsStayed); // At least 1 month
+
+            // Generate bills for each month stayed
+            for ($i = 0; $i < $monthsStayed; $i++) {
+                // Calculate due date (same day as move_in_date each month)
+                $dueDate = $moveInDate->copy()->addMonths($i + 1);
+
+                // Adjust for months with fewer days
+                $daysInMonth = $dueDate->daysInMonth;
+                $dueDay = min($originalDay, $daysInMonth);
+                $dueDate = $dueDate->day($dueDay);
+
+                // Create bill on move_in_date (for first) or previous due date
+                $createdAt = ($i === 0)
+                    ? $moveInDate->copy()
+                    : $moveInDate->copy()->addMonths($i);
+
+                $bill = Bill::create([
+                    'tenant_id' => $tenant->id,
+                    'amount_due' => $tenant->room->rent_amount,
+                    'due_date' => $dueDate,
+                    'status' => BillStatus::UNPAID->value,
+                    'created_at' => $createdAt,
+                    'updated_at' => $createdAt,
+                ]);
+
+                // 70% chance of payment (except for future bills)
+                if ($dueDate->isPast() && fake()->boolean(70)) {
+                    $isOnTime = fake()->boolean(80); // 80% on-time
+
+                    if ($isOnTime) {
+                        // On-time payment between creation and due date
+                        $paymentDate = fake()->dateTimeBetween(
+                            $createdAt->format('Y-m-d'),
+                            $dueDate->format('Y-m-d')
+                        );
+                    } else {
+                        // Late payment (after due date but before now)
+                        $paymentDate = fake()->dateTimeBetween(
+                            $dueDate->addDay()->format('Y-m-d'),
+                            $today->format('Y-m-d')
+                        );
+                    }
+
+                    Transaction::create([
+                        'tenant_id' => $tenant->id,
+                        'bill_id' => $bill->id,
+                        // 'amount' => $bill->amount_due,
+                        'payment_method' => fake()->randomElement($paymentMethods),
+                        'proof_photo' => fake()->boolean(30) ? 'path/to/photo.jpg' : null,
+                        'payment_date' => $paymentDate,
+                        'status' => TransactionStatus::COMPLETED->value,
+                        'confirmed_at' => $paymentDate,
+                    ]);
+
+                    $bill->update(['status' => BillStatus::PAID->value]);
+                } elseif ($dueDate->isPast()) {
+                    $bill->update(['status' => BillStatus::OVERDUE->value]);
+                }
+            }
+        }
     }
 
     /**

--- a/database/seeders/DefaultTestSeeder.php
+++ b/database/seeders/DefaultTestSeeder.php
@@ -106,7 +106,7 @@ class DefaultTestSeeder extends Seeder
                     $rooms[] = Room::create([
                         'property_id' => $property->id,
                         'code' => generate_code(),
-                        'name' => 'Room ' . str_pad($i, 3, '0', STR_PAD_LEFT),
+                        'name' => 'Room '.str_pad($i, 3, '0', STR_PAD_LEFT),
                         'rent_amount' => rand(8, 16) * 500, // 4000-8000
                         'max_occupancy' => rand(1, 6),
                     ]);

--- a/database/seeders/TesterSeeder.php
+++ b/database/seeders/TesterSeeder.php
@@ -24,7 +24,7 @@ class TesterSeeder extends Seeder
 
         // $bill = Bill::find(1);
 
-        $tenant = Tenant::find(1);
+        $tenant = Tenant::find(2);
         $this->command->info('Tenant Outstanding Balance: '.$tenant->outstandingBalance());
 
         // $transaction = Transaction::find(1);

--- a/routes/console.php
+++ b/routes/console.php
@@ -11,5 +11,5 @@ Artisan::command('inspire', function () {
 
 Schedule::command('app:clean-temp-storage public --force')->daily();
 
-Schedule::job(new GenerateBillsJob)->daily();
-Schedule::job(new UpdateOverdueBillsJob)->daily();
+Schedule::job(new GenerateBillsJob)->everyTenSeconds();
+Schedule::job(new UpdateOverdueBillsJob)->everyTenSeconds();


### PR DESCRIPTION
## Description

- Creates a method inside the `DefaultTestSeeder.php` that adds data for our Bills and Transactions
- Added a command for simulating scenarios for our `GenerateBillsJob.php` and `UpdateOverdueBills.php`


## Notes
- Just do `php artisan demo:job` to simulate 1 of the 4 scenarios that we have
- make sure that before simulation, our job scheduling is running by typing the command `php artisan schedule:work` and wait for 10seconds (or wait until the job starts, this usually occur at the first minute to get it in-sync with our system)
